### PR TITLE
Flesh out client keystore and truststores

### DIFF
--- a/doit.sh
+++ b/doit.sh
@@ -102,13 +102,14 @@ keytool -import \
 yes
 EOF
 
-keytool -import \
-  -alias "${NAME}-client" \
-  -file  ${NAME}-client.pem \
-  -keystore ${NAME}-client-truststore.jks \
-  -storepass:env PW << EOF
-yes
-EOF
+# Import CA certs
+keytool -importkeystore \
+  -srckeystore $JAVA_HOME/jre/lib/security/cacerts \
+  -srcstorepass changeit \
+  -srcstoretype jks \
+  -destkeystore ${NAME}-client-truststore.jks \
+  -deststoretype jks \
+  -storepass:env PW
 
 keytool -importkeystore \
   -srckeystore ${NAME}-client-truststore.jks \

--- a/doit.sh
+++ b/doit.sh
@@ -5,39 +5,115 @@
 
 set -x
 
-NAME=prototype
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cfssl gencert -initca ca-csr.json | cfssljson -bare ca
+export NAME=myname
+export ORG=myorg
+
+export PW="changeit"
+
+# If you have pwgen installed, do this
+#export PW=`pwgen -Bs 10 1`
+#echo ${PW} > ${DIR}/password
+# and then in other scripts you can do
+# export PW=`cat password`
+
+cfssl gencert -initca ca-csr.json | cfssljson -bare $ORG-ca
 
 cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem \
+  -ca=$ORG-ca.pem \
+  -ca-key=$ORG-ca-key.pem \
   -config=ca-config.json \
   -profile=server \
    server-csr.json | cfssljson -bare ${NAME}-server
 
 cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem  \
+  -ca=$ORG-ca.pem \
+  -ca-key=$ORG-ca-key.pem  \
   -config=ca-config.json \
   -profile=client \
    client-csr.json | cfssljson -bare ${NAME}-client
 
-openssl pkcs12 -export -out ${NAME}-client.p12 \
-  -inkey ${NAME}-client-key.pem -in ${NAME}-client.pem \
-  -certfile ca.pem
+# Create PKCS12 store and JKS stores for Java based systems.
+#
+# Both formats are broken, so in order to get the correct result
+# we have to treat trust stores and keystore differently.
+#
+# For truststore: create in JKS format, convert to PKCS12
+# For keystores, create in PKCS12 format, convert to JKS.
 
-openssl pkcs12 -export -out ${NAME}-server.p12 \
-  -inkey ${NAME}-server-key.pem -in ${NAME}-server.pem \
-  -certfile ca.pem
+openssl pkcs12 -export \
+  -passout env:PW \
+  -inkey ${NAME}-server-key.pem \
+  -name "$NAME-server" \
+  -in ${NAME}-server.pem \
+  -out ${NAME}-server-keystore.p12
 
-keytool -importkeystore -srckeystore ${NAME}-client.p12 \
-  -storetype pkcs12 -destkeystore ${NAME}-client.jks \
-  -deststoretype jks
+keytool -importkeystore \
+  -srckeystore ${NAME}-server-keystore.p12 \
+  -srcstorepass:env PW \
+  -alias "$NAME-server" \
+  -srckeypass:env PW \
+  -srcstoretype pkcs12 \
+  -destkeystore ${NAME}-server-keystore.jks \
+  -deststoretype jks \
+  -deststorepass:env PW
 
-keytool -importkeystore -srckeystore ${NAME}-server.p12 \
-  -storetype pkcs12 -destkeystore ${NAME}-server.jks \
-  -deststoretype jks
+keytool -import \
+  -alias $ORG-ca \
+  -file  $ORG-ca.pem \
+  -keystore ${NAME}-server-truststore.jks \
+  -storepass:env PW << EOF
+yes
+EOF
 
-keytool -import -file ca.pem -alias "${NAME}CA" \
-  -keystore truststore.jks
+keytool -importkeystore \
+  -srckeystore ${NAME}-server-truststore.jks \
+  -srcstorepass:env PW \
+  -srcstoretype JKS \
+  -destkeystore ${NAME}-server-truststore.p12 \
+  -deststoretype PKCS12 \
+  -deststorepass:env PW
+
+## Client keystore and trust store
+
+openssl pkcs12 -export \
+  -passout env:PW \
+  -inkey ${NAME}-client-key.pem \
+  -name "$NAME-client" \
+  -in ${NAME}-client.pem \
+  -out ${NAME}-client-keystore.p12 
+
+keytool -importkeystore \
+  -srckeystore ${NAME}-client-keystore.p12 \
+  -srcstorepass:env PW \
+  -alias "$NAME-client" \
+  -srckeypass:env PW \
+  -srcstoretype pkcs12 \
+  -destkeystore ${NAME}-client-keystore.jks \
+  -deststoretype jks \
+  -deststorepass:env PW
+
+keytool -import \
+  -alias $ORG-ca \
+  -file  $ORG-ca.pem \
+  -keystore ${NAME}-client-truststore.jks \
+  -storepass:env PW << EOF
+yes
+EOF
+
+keytool -import \
+  -alias "${NAME}-client" \
+  -file  ${NAME}-client.pem \
+  -keystore ${NAME}-client-truststore.jks \
+  -storepass:env PW << EOF
+yes
+EOF
+
+keytool -importkeystore \
+  -srckeystore ${NAME}-client-truststore.jks \
+  -srcstorepass:env PW \
+  -srcstoretype jks \
+  -destkeystore ${NAME}-client-truststore.p12 \
+  -deststoretype pkcs12 \
+  -deststorepass:env PW

--- a/doit.sh
+++ b/doit.sh
@@ -84,6 +84,8 @@ openssl pkcs12 -export \
   -inkey ${NAME}-client-key.pem \
   -name "$NAME-client" \
   -in ${NAME}-client.pem \
+  -chain \
+  -CAfile $ORG-ca.pem \
   -out ${NAME}-client-keystore.p12 
 
 keytool -importkeystore \

--- a/doit.sh
+++ b/doit.sh
@@ -47,6 +47,8 @@ openssl pkcs12 -export \
   -inkey ${NAME}-server-key.pem \
   -name "$NAME-server" \
   -in ${NAME}-server.pem \
+  -chain \
+  -CAfile $ORG-ca.pem \
   -out ${NAME}-server-keystore.p12
 
 keytool -importkeystore \

--- a/doit.sh
+++ b/doit.sh
@@ -7,7 +7,7 @@ set -x
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-export NAME=myname
+export NAME=prototype
 export ORG=myorg
 
 export PW="changeit"


### PR DESCRIPTION
I had to get client certificates working with a CA and wanted to set up different truststores for client and server, with the trust stores containing no private keys.

I tweaked things a bit to add an organization prefix and to use the password throughout the system in both openssl, and to break statements over multiple lines where the parameter had required arguments.

Probably need a link to https://stackoverflow.com/a/907515 to expand on the problem with keytool and private keys.  

There may be a way to use openssl to import certificates without private keys, but when I used `-nokeys` to import just the `ca.pem`, it would tell me there was nothing in the PKCS12 file at all.  Keytool was fine with that, so I just did it in the reverse direction.